### PR TITLE
fix: 회원 좋아요 리스트 비어있을 때 NumberFormatException 처리

### DIFF
--- a/src/main/java/com/hotsix/iAmNotAlone/domain/post/service/PostDetailService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/post/service/PostDetailService.java
@@ -37,12 +37,15 @@ public class PostDetailService {
         Membership membership = membershipRepository.findById(membershipId).orElseThrow(
             () -> new BusinessException(NOT_FOUND_USER)
         );
-        List<Long> likeList = membership.getLikelist().stream().map(Long::parseLong).collect(
+        // 좋아요 확인
+        List<Long> likeList = membership.getLikelist().stream().filter(s->!s.isEmpty()).map(Long::parseLong).collect(
             Collectors.toList());
-        Long likeCount = redisUtil.getLikeCount("likes:" + postId);
+        postDetailDto.setLike(likeList.isEmpty() ? false : likeList.contains(postId));
 
+        //좋아요 수
+        Long likeCount = redisUtil.getLikeCount("likes:" + postId);
         postDetailDto.setLikes(likeCount);
-        postDetailDto.setLike(likeList.contains(postId));
+
         return postDetailDto;
     }
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 회원 좋아요 리스트 비어있을 때 NumberFormatException 발생

**TO-BE**
- filter로 한번 걸러서 처리하도록 함
