### PR TITLE
Refactor : Post,Comment 수정

### DIFF
--- a/src/main/java/com/hotsix/iAmNotAlone/domain/comments/entity/Comments.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/comments/entity/Comments.java
@@ -4,20 +4,14 @@ import com.hotsix.iAmNotAlone.domain.comments.model.form.CommentRequestForm;
 import com.hotsix.iAmNotAlone.domain.common.BaseEntity;
 import com.hotsix.iAmNotAlone.domain.membership.entity.Membership;
 import com.hotsix.iAmNotAlone.domain.post.entity.Post;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.*;
 
 @Entity
 @Getter
@@ -43,7 +37,6 @@ public class Comments extends BaseEntity {
     @Column(length = 3000)
     private String content;
 
-
     public static Comments createComments(CommentRequestForm form, Membership membership, Post post) {
         return Comments.builder()
                 .post(post)
@@ -51,14 +44,6 @@ public class Comments extends BaseEntity {
                 .content(form.getContent())
                 .build();
     }
-
-//    private void setPost(Post post) {
-//        if (this.post != null) { // 기존에 이미 팀이 존재한다면
-//            this.post.getCommentsList().remove(this); // 관계를 끊는다.
-//        }
-//        this.post = post;
-//        post.getCommentsList().add(this);
-//    }
 
     public void updateContent(String content) {
         this.content = content;

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/comments/model/dto/CommentsDetailResponseDto.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/comments/model/dto/CommentsDetailResponseDto.java
@@ -13,11 +13,13 @@ public class CommentsDetailResponseDto {
     private String img_path;
     private LocalDateTime createdAt;
     private String content;
+    private Long commentId;
 
     public CommentsDetailResponseDto(Comments comments) {
         nickName = comments.getMembership().getNickname();
         img_path = comments.getMembership().getImgPath();
         createdAt = comments.getCreatedAt();
         content = comments.getContent();
+        commentId = comments.getId();
     }
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/comments/repository/CommentsRepository.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/comments/repository/CommentsRepository.java
@@ -3,6 +3,7 @@ package com.hotsix.iAmNotAlone.domain.comments.repository;
 import com.hotsix.iAmNotAlone.domain.comments.entity.Comments;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,16 +12,12 @@ import java.util.List;
 
 public interface CommentsRepository extends JpaRepository<Comments, Long> {
 
-
-    @Query(value = "select c from Comments c" +
-            " join fetch c.membership m" +
-            " where c.post.id = :postId")
-    List<Comments> findByPost(@Param("postId") Long postId);
-
+    @EntityGraph(attributePaths = {"membership"})
     List<Comments> findTop10ByPostIdOrderByIdAsc(Long postId);
 
-    Page<Comments> findByIdGreaterThanAndPostIdOrderByIdAsc(Long lastCommentId, Long postId,
-        PageRequest pageRequest);
+    Page<Comments> findByIdGreaterThanAndPostIdOrderByIdAsc(Long lastCommentId, Long postId, PageRequest pageRequest);
 
-    Long countByPostId(Long postId);
+    @Query("select count(c) from Comments c where c.post.id = :postId")
+    Long countByPostId(@Param("postId") Long postId);
+
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/comments/service/CommentPageService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/comments/service/CommentPageService.java
@@ -25,11 +25,10 @@ public class CommentPageService {
     // 페이지
     public List<CommentsDetailResponseDto> commentPagesBy(Long lastCommentId, int size, Long postId) {
 
-        Post post = postRepository.findById(postId).orElseThrow(
+        postRepository.findById(postId).orElseThrow(
                 () -> new BusinessException(ErrorCode.NOT_FOUND_POST)
         );
-        Long postNum = post.getId();
-        Page<Comments> comments = fetchPages(lastCommentId, size, postNum);
+        Page<Comments> comments = fetchPages(lastCommentId, size, postId);
         List<Comments> content = comments.getContent();
 
         return content.stream()

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/comments/service/CommentsRegisterService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/comments/service/CommentsRegisterService.java
@@ -40,13 +40,4 @@ public class CommentsRegisterService {
         return comments.getId();
     }
 
-    @Transactional
-    public List<CommentsDetailResponseDto> getCommentsDetail(Long postId) {
-
-        List<Comments> comments = commentsRepository.findByPost(postId);
-
-        return comments.stream().map(
-                        c -> new CommentsDetailResponseDto(c))
-                .collect(Collectors.toList());
-    }
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/post/entity/Post.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/post/entity/Post.java
@@ -5,22 +5,10 @@ import com.hotsix.iAmNotAlone.domain.membership.entity.Membership;
 import com.hotsix.iAmNotAlone.domain.post.model.form.AddPostForm;
 import com.hotsix.iAmNotAlone.domain.post.model.form.ModifyPostForm;
 import com.hotsix.iAmNotAlone.global.util.ListToStringConverter;
-import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Convert;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.envers.AuditOverride;
+import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Getter
@@ -61,8 +49,6 @@ public class Post extends BaseEntity {
     @Convert(converter = ListToStringConverter.class)
     @Column(name = "img_path")
     private List<String> imgPath;
-
-
 
     public static Post createPost(AddPostForm form, Membership membership, List<String> path) {
         return Post.builder()

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/post/model/dto/PostResponseDto.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/post/model/dto/PostResponseDto.java
@@ -13,9 +13,10 @@ public class PostResponseDto {
     private int gender;
     private LocalDateTime createdAt;
     private String content;
-    private int commentCount;
+    private Long commentCount;
     private Long postId;
     private String postImgPath;
+    private boolean likeYn;
 
     public PostResponseDto(Post post) {
 
@@ -24,9 +25,9 @@ public class PostResponseDto {
         gender = post.getMembership().getGender();
         createdAt = post.getCreatedAt();
         content = removeContent(post.getContent());
-//        commentCount = post.getCommentsList().size();
         postId = post.getId();
         postImgPath = post.getImgPath().get(0);
+        likeYn = likeCheck(post.getLikes());
     }
 
     public String removeContent(String content) {
@@ -35,6 +36,13 @@ public class PostResponseDto {
             content += "...더보기";
         }
         return content;
+    }
+
+    public boolean likeCheck(Long likeLength){
+        if (likeLength>0){
+            return true;
+        }
+        return false;
     }
 
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/post/repository/PostRepository.java
@@ -15,9 +15,11 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
+    // 마이페이지 무한스크롤
     Page<Post> findByIdLessThanAndMembershipIdOrderByIdDesc(Long lastPostId, Long membershipId, PageRequest pageRequest);
 
-    List<Post> findTop5ByMembershipIdOrderByIdDesc(Long loginMemberId);
+    // 마이페이지 게시글 세팅
+    List<Post> findTop10ByMembershipIdOrderByIdDesc(Long loginMemberId);
 
     @Override
     @EntityGraph(attributePaths = {"membership"})

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/post/service/PostPageService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/post/service/PostPageService.java
@@ -1,17 +1,19 @@
 package com.hotsix.iAmNotAlone.domain.post.service;
 
-import com.hotsix.iAmNotAlone.domain.membership.entity.Membership;
+import com.hotsix.iAmNotAlone.domain.comments.repository.CommentsRepository;
 import com.hotsix.iAmNotAlone.domain.membership.repository.MembershipRepository;
 import com.hotsix.iAmNotAlone.domain.post.entity.Post;
 import com.hotsix.iAmNotAlone.domain.post.model.dto.PostResponseDto;
 import com.hotsix.iAmNotAlone.domain.post.repository.PostRepository;
+import com.hotsix.iAmNotAlone.global.exception.business.BusinessException;
+import com.hotsix.iAmNotAlone.global.exception.business.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -19,17 +21,25 @@ public class PostPageService {
 
     private final PostRepository postRepository;
     private final MembershipRepository membershipRepository;
+    private final CommentsRepository commentsRepository;
 
     // 페이지
     public List<PostResponseDto> postPagesBy(Long lastPostId, int size, Long userId) {
-        Membership loginMember = membershipRepository.findById(userId).get();
-        Long memberId = loginMember.getId();
-        Page<Post> posts = fetchPages(lastPostId, size, memberId);
-        List<Post> content = posts.getContent();
+        membershipRepository.findById(userId).orElseThrow(
+                ()->new BusinessException(ErrorCode.NOT_FOUND_USER)
+        );
+        Page<Post> posts = fetchPages(lastPostId, size, userId);
+        List<Post> postList = posts.getContent();
 
-        return content.stream()
-                .map(t -> new PostResponseDto(t))
-                .collect(Collectors.toList());
+        List<PostResponseDto> postResponseList = new ArrayList<>();
+
+        for (Post post : postList) {
+            PostResponseDto postResponseDto = new PostResponseDto(post);
+            Long commentCount = commentsRepository.countByPostId(post.getId());
+            postResponseDto.setCommentCount(commentCount);
+            postResponseList.add(postResponseDto);
+        }
+        return postResponseList;
     }
 
     public Page<Post> fetchPages(Long lastPostId, int size, Long loginMemberId) {
@@ -40,12 +50,20 @@ public class PostPageService {
 
     // 페이지 기본 세팅
     public List<PostResponseDto> postBasicSetting(Long userId) {
-        Membership loginMember = membershipRepository.findById(userId).get();
-        Long loginMemberId = loginMember.getId();
-        List<Post> postList = postRepository.findTop5ByMembershipIdOrderByIdDesc(loginMemberId);
-        return postList.stream()
-                .map(p -> new PostResponseDto(p))
-                .collect(Collectors.toList());
+        membershipRepository.findById(userId).orElseThrow(
+                ()->new BusinessException(ErrorCode.NOT_FOUND_USER)
+        );
+        List<Post> postList = postRepository.findTop10ByMembershipIdOrderByIdDesc(userId);
+
+        List<PostResponseDto> postResponseList = new ArrayList<>();
+
+        for (Post post : postList) {
+            PostResponseDto postResponseDto = new PostResponseDto(post);
+            Long commentCount = commentsRepository.countByPostId(post.getId());
+            postResponseDto.setCommentCount(commentCount);
+            postResponseList.add(postResponseDto);
+        }
+        return postResponseList;
     }
 
 }


### PR DESCRIPTION
**AS-IS**
- Post 엔티티와 Comment 엔티티 양방향 -> 단반향
- Comment 엔티티만 @ManyToOne Post post 를 가지고 있음
- 게시물 가져올때 게시물 댓글 개수를 한번에 가져오려고 했지만 성능을 고려해 댓글 개수를 인덱스를 통해 바로 가져오도록 개발

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 