### PR TITLE
feat: 회원 탈퇴시 게시글과 게시글에 포함된 이미지 삭제 로직 추가

### DIFF
--- a/src/main/java/com/hotsix/iAmNotAlone/domain/membership/service/MembershipRemoveService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/membership/service/MembershipRemoveService.java
@@ -4,6 +4,7 @@ import static com.hotsix.iAmNotAlone.global.exception.business.ErrorCode.NOT_FOU
 
 import com.hotsix.iAmNotAlone.domain.membership.entity.Membership;
 import com.hotsix.iAmNotAlone.domain.membership.repository.MembershipRepository;
+import com.hotsix.iAmNotAlone.domain.post.service.PostRemoveService;
 import com.hotsix.iAmNotAlone.global.exception.business.BusinessException;
 import com.hotsix.iAmNotAlone.global.util.S3UploadService;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ public class MembershipRemoveService {
 
     private final MembershipRepository membershipRepository;
     private final S3UploadService s3UploadService;
+    private final PostRemoveService postRemoveService;
 
     /**
      * 회원 삭제
@@ -31,6 +33,7 @@ public class MembershipRemoveService {
             s3UploadService.deleteFile(split[1]);
         }
 
+        postRemoveService.removeAllPost(id);
         membershipRepository.deleteById(id);
     }
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/post/repository/PostRepository.java
@@ -10,7 +10,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -23,6 +25,14 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Override
     @EntityGraph(attributePaths = {"membership"})
     Optional<Post> findById(Long postI7);
+
+    @Modifying
+    @Query("SELECT p from Post p where p.membership.id = :membershipId")
+    List<Post> findAllByMembershipId(@Param("membershipId") Long id);
+
+    @Modifying
+    @Query("DELETE from Post p where p.membership.id = :membershipId")
+    void deleteAllByMembershipId(@Param("membershipId") Long id);
 
 
     @Query("    SELECT p.boardId                    AS boardId"

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/post/service/PostRemoveService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/post/service/PostRemoveService.java
@@ -5,6 +5,7 @@ import com.hotsix.iAmNotAlone.domain.post.repository.PostRepository;
 import com.hotsix.iAmNotAlone.global.exception.business.BusinessException;
 import com.hotsix.iAmNotAlone.global.exception.business.ErrorCode;
 import com.hotsix.iAmNotAlone.global.util.S3UploadService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -32,5 +33,19 @@ public class PostRemoveService {
             }
         }
         postRepository.deleteById(id);
+    }
+
+    @Transactional
+    public void removeAllPost(Long id) {
+        List<Post> postList = postRepository.findAllByMembershipId(id);
+        for (Post p : postList) {
+            if (p.getImgPath().get(0).length() != 0) {
+                for (String url : p.getImgPath()) {
+                    String[] split = url.split("com/");
+                    s3UploadService.deleteFile(split[1]);
+                }
+            }
+        }
+        postRepository.deleteAllByMembershipId(id);
     }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**


**TO-BE**
- 회원탈퇴시 탈퇴한 회원이 작성한 게시글과 게시글에 포함된 이미지 삭제 로직 추가
- fk를 걸고 @OnDelete어노테이션을 사용해서 삭제를 하면 게시글에 포함된 이미지를 s3상에서 지울 수가 없어서 이미지 삭제하는 로직을 추가함

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 