### PR TITLE
Feat : 카카오 소셜로그인 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 
 	// https://mvnrepository.com/artifact/com.auth0/java-jwt
 	implementation group: 'com.auth0', name: 'java-jwt', version: '4.3.0'
+
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/hotsix/iAmNotAlone/IAmNotAloneApplication.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/IAmNotAloneApplication.java
@@ -3,8 +3,11 @@ package com.hotsix.iAmNotAlone;
 import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootApplication
 @EnableJpaAuditing
@@ -14,5 +17,10 @@ public class IAmNotAloneApplication {
 		SpringApplication.run(IAmNotAloneApplication.class, args);
 		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 		// jenkins CICD Test
+	}
+
+	@Bean  // 비밀번호 암호화
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
 	}
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/IAmNotAloneApplication.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/IAmNotAloneApplication.java
@@ -23,4 +23,5 @@ public class IAmNotAloneApplication {
 	public PasswordEncoder passwordEncoder() {
 		return new BCryptPasswordEncoder();
 	}
+
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/membership/controller/SignUpController.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/membership/controller/SignUpController.java
@@ -1,16 +1,15 @@
 package com.hotsix.iAmNotAlone.domain.membership.controller;
 
 import com.hotsix.iAmNotAlone.domain.membership.model.form.AddMembershipForm;
+import com.hotsix.iAmNotAlone.domain.membership.model.form.AddMembershipOAuthForm;
 import com.hotsix.iAmNotAlone.domain.membership.model.form.VerifyNicknameForm;
+import com.hotsix.iAmNotAlone.domain.membership.service.OAuthSignUpService;
 import com.hotsix.iAmNotAlone.domain.membership.service.SignUpService;
 import com.hotsix.iAmNotAlone.global.auth.jwt.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
@@ -23,12 +22,13 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @RequiredArgsConstructor
 public class SignUpController {
 
+    private final OAuthSignUpService oAuthSignUpService;
     private final SignUpService signUpService;
     private final JwtService jwtService;
 
     @PostMapping(value = "/signup", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<Long> signUp(@RequestPart AddMembershipForm form,
-        @RequestPart(value = "files", required = false) MultipartFile multipartFile) {
+                                       @RequestPart(value = "files", required = false) MultipartFile multipartFile) {
         return ResponseEntity.ok(signUpService.signUp(form, multipartFile));
     }
 
@@ -38,10 +38,15 @@ public class SignUpController {
     }
 
     @PostMapping("/refresh")
-    public void refresh(HttpServletRequest request , HttpServletResponse response) throws IOException {
+    public void refresh(HttpServletRequest request, HttpServletResponse response) throws IOException {
         String refresh = jwtService.refresh(request, response);
         response.setContentType(APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("utf-8");
         response.getWriter().write(refresh);
+    }
+
+    @PatchMapping("/oauth/signup/{id}")
+    public ResponseEntity<Long> oauthSignUp(@RequestBody AddMembershipOAuthForm form, @PathVariable Long id) {
+        return ResponseEntity.ok(oAuthSignUpService.oAuthSignUp(form, id));
     }
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/membership/controller/SignUpController.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/membership/controller/SignUpController.java
@@ -49,4 +49,5 @@ public class SignUpController {
     public ResponseEntity<Long> oauthSignUp(@RequestBody AddMembershipOAuthForm form, @PathVariable Long id) {
         return ResponseEntity.ok(oAuthSignUpService.oAuthSignUp(form, id));
     }
+
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/membership/entity/Membership.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/membership/entity/Membership.java
@@ -129,4 +129,5 @@ public class Membership extends BaseEntity {
             this.gender = form.getGender();
         }
     }
+
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/membership/entity/Membership.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/membership/entity/Membership.java
@@ -2,25 +2,11 @@ package com.hotsix.iAmNotAlone.domain.membership.entity;
 
 import com.hotsix.iAmNotAlone.domain.common.BaseEntity;
 import com.hotsix.iAmNotAlone.domain.membership.model.form.AddMembershipForm;
+import com.hotsix.iAmNotAlone.domain.membership.model.form.AddMembershipOAuthForm;
 import com.hotsix.iAmNotAlone.domain.membership.model.form.ModifyMembershipForm;
 import com.hotsix.iAmNotAlone.domain.region.entity.Region;
 import com.hotsix.iAmNotAlone.global.auth.common.Role;
 import com.hotsix.iAmNotAlone.global.util.ListToStringConverter;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Convert;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Builder.Default;
@@ -28,10 +14,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.envers.AuditOverride;
 
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @AllArgsConstructor
 @AuditOverride(forClass = BaseEntity.class)
 public class Membership extends BaseEntity {
@@ -115,6 +106,27 @@ public class Membership extends BaseEntity {
             this.likelist.add(String.valueOf(postId));
         } else {
             this.likelist.remove(String.valueOf(postId));
+        }
+    }
+
+    public void updateMembership(AddMembershipOAuthForm form, Region region) {
+        if (form.getNickname() != null) {
+            this.nickname = form.getNickname();
+        }
+        if (form.getIntroduction() != null) {
+            this.introduction = form.getIntroduction();
+        }
+        if (form.getBirth() != null) {
+            this.birth = form.getBirth();
+        }
+        if (region != null) {
+            this.region = region;
+        }
+        if (form.getPersonality() != null) {
+            this.personality = form.getPersonality();
+        }
+        if (form.getGender() != null) {
+            this.gender = form.getGender();
         }
     }
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/membership/model/form/AddMembershipOAuthForm.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/membership/model/form/AddMembershipOAuthForm.java
@@ -25,4 +25,5 @@ public class AddMembershipOAuthForm {
     private Long regionId;
     private List<String> personality;
 
+
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/membership/model/form/AddMembershipOAuthForm.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/membership/model/form/AddMembershipOAuthForm.java
@@ -1,0 +1,28 @@
+package com.hotsix.iAmNotAlone.domain.membership.model.form;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class AddMembershipOAuthForm {
+
+    private String nickname;
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate birth;
+    private Integer gender;
+    private String introduction;
+    private Long regionId;
+    private List<String> personality;
+
+}

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/membership/service/OAuthSignUpService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/membership/service/OAuthSignUpService.java
@@ -1,0 +1,51 @@
+package com.hotsix.iAmNotAlone.domain.membership.service;
+
+import com.hotsix.iAmNotAlone.domain.membership.entity.Membership;
+import com.hotsix.iAmNotAlone.domain.membership.model.form.AddMembershipOAuthForm;
+import com.hotsix.iAmNotAlone.domain.membership.repository.MembershipRepository;
+import com.hotsix.iAmNotAlone.domain.region.entity.Region;
+import com.hotsix.iAmNotAlone.domain.region.repository.RegionRepository;
+import com.hotsix.iAmNotAlone.global.exception.business.BusinessException;
+import com.hotsix.iAmNotAlone.global.exception.business.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.hotsix.iAmNotAlone.global.exception.business.ErrorCode.ALREADY_EXIST_NICKNAME;
+import static com.hotsix.iAmNotAlone.global.exception.business.ErrorCode.NOT_FOUND_REGION;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class OAuthSignUpService {
+
+    private final MembershipRepository membershipRepository;
+    private final RegionRepository regionRepository;
+
+    @Transactional
+    public Long oAuthSignUp(AddMembershipOAuthForm form, Long id) {
+        Region region = regionRepository.findById(form.getRegionId()).orElseThrow(
+                () -> new BusinessException(NOT_FOUND_REGION)
+        );
+
+        Membership membership = membershipRepository.findById(id).orElseThrow(
+                () -> new BusinessException(ErrorCode.NOT_FOUND_USER)
+        );
+
+        membership.updateMembership(form, region);
+
+        return membership.getId();
+    }
+
+    /**
+     * 닉네임 중복 검사
+     */
+    public boolean validateNickname(String nickname) {
+        if (membershipRepository.existsByNickname(nickname)) {
+            throw new BusinessException(ALREADY_EXIST_NICKNAME);
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/membership/service/OAuthSignUpService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/membership/service/OAuthSignUpService.java
@@ -48,4 +48,5 @@ public class OAuthSignUpService {
         }
         return true;
     }
+
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/post/service/PostPageService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/post/service/PostPageService.java
@@ -7,6 +7,7 @@ import com.hotsix.iAmNotAlone.domain.membership.service.MembershipGetInfoForMain
 import com.hotsix.iAmNotAlone.domain.post.entity.Post;
 import com.hotsix.iAmNotAlone.domain.post.model.dto.PostResponseDto;
 import com.hotsix.iAmNotAlone.domain.post.repository.PostRepository;
+import com.hotsix.iAmNotAlone.domain.region.repository.RegionRepository;
 import com.hotsix.iAmNotAlone.global.exception.business.BusinessException;
 import com.hotsix.iAmNotAlone.global.exception.business.ErrorCode;
 import java.util.ArrayList;
@@ -24,6 +25,7 @@ public class PostPageService {
     private final MembershipRepository membershipRepository;
     private final CommentsRepository commentsRepository;
     private final MembershipGetInfoForMainService forMainService;
+    private final RegionRepository regionRepository;
 
     // 페이지
     public List<PostResponseDto> postPagesBy(Long lastPostId, int size, Long userId) {
@@ -67,6 +69,7 @@ public class PostPageService {
 
             Long commentCount = commentsRepository.countByPostId(post.getId());
             boolean likesFlag = !likeList.isEmpty() && likeList.contains(post.getId());
+
             PostResponseDto postResponseDto = PostResponseDto.of(post, commentCount, likesFlag);
             postResponseList.add(postResponseDto);
         }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/post/service/PostPageService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/post/service/PostPageService.java
@@ -73,7 +73,6 @@ public class PostPageService {
             PostResponseDto postResponseDto = PostResponseDto.of(post, commentCount, likesFlag);
             postResponseList.add(postResponseDto);
         }
-
         return postResponseList;
     }
 

--- a/src/main/java/com/hotsix/iAmNotAlone/global/auth/PrincipalDetails.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/global/auth/PrincipalDetails.java
@@ -78,4 +78,5 @@ public class PrincipalDetails implements UserDetails, OAuth2User {
         return attributes;
     }
 
+
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/global/auth/PrincipalDetails.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/global/auth/PrincipalDetails.java
@@ -1,25 +1,39 @@
 package com.hotsix.iAmNotAlone.global.auth;
 
 import com.hotsix.iAmNotAlone.domain.membership.entity.Membership;
-import java.util.ArrayList;
-import java.util.Collection;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
 
 @Getter
-public class PrincipalDetails implements UserDetails {
+@Slf4j
+public class PrincipalDetails implements UserDetails, OAuth2User {
 
-    private final Membership member;
+    private Membership member;
+    private Map<String, Object> attributes;
 
+    // 일반 로그인
     public PrincipalDetails(Membership member) {
         this.member = member;
+    }
+
+    // OAuth 로그인
+    public PrincipalDetails(Membership member, Map<String, Object> attributes) {
+        this.member = member;
+        this.attributes = attributes;
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> authorities = new ArrayList<>();
+        log.info("PrincipalDetails{}" + member.getRole());
         authorities.add(new SimpleGrantedAuthority("ROLE_" + member.getRole().toString()));
         return authorities;
     }
@@ -53,4 +67,15 @@ public class PrincipalDetails implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
+
+    @Override
+    public String getName() {
+        return attributes.get("email").toString();
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/global/auth/PrincipalDetailsService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/global/auth/PrincipalDetailsService.java
@@ -26,4 +26,5 @@ public class PrincipalDetailsService implements UserDetailsService {
             throw new UsernameNotFoundException("이메일이 없습니다.");
         }
     }
+
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/global/auth/jwt/JwtService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/global/auth/jwt/JwtService.java
@@ -31,13 +31,13 @@ public class JwtService {
 
     private final MembershipRepository membershipRepository;
 
-    public String createAccessToken(Long id,String email) {
+    public String createAccessToken(Long id, String email) {
         log.info("어세스 토큰 생성");
         String token = JWT.create()
                 .withSubject(ACCESS_TOKEN_SUBJECT)
                 .withExpiresAt(new Date(System.currentTimeMillis() + ACCESS_EXPIRATION_TIME * 1000))
                 .withClaim("email", email)
-                .withClaim("id",id)
+                .withClaim("id", id)
                 .sign(Algorithm.HMAC512(SECRET));
 
         return TOKEN_PREFIX + token;
@@ -114,7 +114,6 @@ public class JwtService {
     }
 
     public String refresh(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        Map<String, String> map = new HashMap<>();
         ObjectMapper om = new ObjectMapper();
         log.info("refresh 유효성 확인");
         String refreshToken = request.getHeader(REFRESH_TOKEN_SUBJECT);
@@ -127,7 +126,7 @@ public class JwtService {
             Optional<Membership> optionalToken = membershipRepository.findByRefreshToken(refreshToken);
             if (optionalToken.isPresent()) {
                 Membership member = optionalToken.get();
-                Map<String, String> map1 = sendAccessToken(response, createAccessToken(member.getId(),member.getEmail()));
+                Map<String, String> map1 = sendAccessToken(response, createAccessToken(member.getId(), member.getEmail()));
                 return om.writeValueAsString(map1);
             }
         } else {
@@ -137,4 +136,3 @@ public class JwtService {
         return "";
     }
 }
-

--- a/src/main/java/com/hotsix/iAmNotAlone/global/auth/jwt/JwtService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/global/auth/jwt/JwtService.java
@@ -135,4 +135,5 @@ public class JwtService {
         }
         return "";
     }
+
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/global/auth/oauth/PrincipalOauth2UserService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/global/auth/oauth/PrincipalOauth2UserService.java
@@ -106,8 +106,6 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
         writeResponse(membership.getId().toString());
         jwtService.updateRefreshToken(email, refreshToken);
 
-
-
         return new PrincipalDetails(membership, oAuth2User.getAttributes());
     }
 

--- a/src/main/java/com/hotsix/iAmNotAlone/global/auth/oauth/PrincipalOauth2UserService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/global/auth/oauth/PrincipalOauth2UserService.java
@@ -1,0 +1,121 @@
+package com.hotsix.iAmNotAlone.global.auth.oauth;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hotsix.iAmNotAlone.domain.membership.entity.Membership;
+import com.hotsix.iAmNotAlone.domain.membership.repository.MembershipRepository;
+import com.hotsix.iAmNotAlone.global.auth.PrincipalDetails;
+import com.hotsix.iAmNotAlone.global.auth.jwt.JwtService;
+import com.hotsix.iAmNotAlone.global.util.S3UploadService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.hotsix.iAmNotAlone.global.auth.common.Role.USER;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final MembershipRepository membershipRepository;
+    private final JwtService jwtService;
+    private final S3UploadService s3UploadService;
+    private final HttpServletResponse servletResponse;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        String clientId = userRequest.getClientRegistration().getClientId();
+
+        // 비밀번호는 db에 저장하는 용도 실제 사용자가 쓰지 않음
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+
+        String url = "";
+
+        String email = (String) kakaoAccount.get("email");
+        String nickname = (String) properties.get("nickname");
+        String imgPath = (String) properties.get("profile_image");
+        String password = passwordEncoder.encode(clientId);
+
+        url = s3UploadService.OAuthUploadFile(imgPath).getUploadFileUrl();
+
+        Optional<Membership> memberOptional = membershipRepository.findByEmail(email);
+
+        if (!memberOptional.isPresent()) {
+            return handleNewMembership(email, password, nickname, url, oAuth2User);
+        } else {
+            return handleExistingMembership(memberOptional.get(), email, oAuth2User);
+        }
+    }
+
+    private OAuth2User handleNewMembership(String email, String password, String nickname, String imgPath, OAuth2User oAuth2User) {
+        Membership membership = Membership.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .imgPath(imgPath)
+                .role(USER)
+                .build();
+        Membership savedMember = membershipRepository.save(membership);
+
+        writeResponse(savedMember.getId().toString());
+        try {
+            servletResponse.sendRedirect("/socialsignup.html");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return new PrincipalDetails(membership, oAuth2User.getAttributes());
+    }
+
+    private OAuth2User handleExistingMembership(Membership membership, String email, OAuth2User oAuth2User) {
+        ObjectMapper om = new ObjectMapper();
+        log.info("소셜 로그인 성공");
+
+        String accessToken = jwtService.createAccessToken(membership.getId(), email);
+        String refreshToken = jwtService.createRefreshToken();
+
+        Map<String, String> accessRefreshMap = jwtService.sendAccessAndRefreshToken(servletResponse, accessToken, refreshToken);
+        String jsonAccessRefreshMap = null;
+
+        try {
+            jsonAccessRefreshMap = om.writeValueAsString(accessRefreshMap);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        log.info(jsonAccessRefreshMap);
+        servletResponse.setContentType(APPLICATION_JSON_VALUE);
+        servletResponse.setCharacterEncoding("utf-8");
+
+        writeResponse(jsonAccessRefreshMap);
+        writeResponse(membership.getId().toString());
+        jwtService.updateRefreshToken(email, refreshToken);
+
+
+
+        return new PrincipalDetails(membership, oAuth2User.getAttributes());
+    }
+
+    private void writeResponse(String response) {
+        try {
+            servletResponse.getWriter().write(response);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/hotsix/iAmNotAlone/global/config/SecurityConfig.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/global/config/SecurityConfig.java
@@ -70,5 +70,4 @@ public class SecurityConfig {
                     .addFilter(new JwtAuthorizationFilter(authenticationManager, membershipRepository, jwtService));
         }
     }
-
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/global/config/SecurityConfig.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/global/config/SecurityConfig.java
@@ -4,7 +4,7 @@ import com.hotsix.iAmNotAlone.domain.membership.repository.MembershipRepository;
 import com.hotsix.iAmNotAlone.global.auth.jwt.JwtService;
 import com.hotsix.iAmNotAlone.global.auth.jwt.filter.JwtAuthenticationFilter;
 import com.hotsix.iAmNotAlone.global.auth.jwt.filter.JwtAuthorizationFilter;
-//import com.hotsix.iAmNotAlone.global.auth.oauth.PrincipalOauth2UserService;
+import com.hotsix.iAmNotAlone.global.auth.oauth.PrincipalOauth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -15,8 +15,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -27,7 +25,7 @@ public class SecurityConfig {
     private final JwtService jwtService;
     private final CorsConfig corsConfig;
     private final MembershipRepository membershipRepository;
-//    private final PrincipalOauth2UserService principalOauth2UserService;
+    private final PrincipalOauth2UserService principalOauth2UserService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -42,14 +40,14 @@ public class SecurityConfig {
                 .and()
                 .authorizeRequests(authorize -> authorize
                         .antMatchers("/login", "/signup", "/email/**", "/swagger-ui/**", "/v3/api-docs/**"
-                                , "/swagger-resources/**", "/refresh", "/post").permitAll()
+                                , "/swagger-resources/**", "/refresh", "/post", "/oauth/signup").permitAll()
                         .antMatchers("/api/**").access("hasRole('ROLE_USER')"));
 
-//        http
-//                .oauth2Login()
-//                .loginPage("/login")
-//                .userInfoEndpoint()
-////                .userService(principalOauth2UserService);
+        http
+                .oauth2Login()
+                .loginPage("/login")
+                .userInfoEndpoint()
+                .userService(principalOauth2UserService);
 
         return http.build();
     }
@@ -68,13 +66,9 @@ public class SecurityConfig {
             AuthenticationManager authenticationManager = http.getSharedObject(AuthenticationManager.class);
             http
                     .addFilter(corsConfig.corsFilter())
-                    .addFilter(new JwtAuthenticationFilter(authenticationManager, membershipRepository,jwtService))
+                    .addFilter(new JwtAuthenticationFilter(authenticationManager, membershipRepository, jwtService))
                     .addFilter(new JwtAuthorizationFilter(authenticationManager, membershipRepository, jwtService));
         }
     }
 
-    @Bean  // 비밀번호 암호화
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/global/util/S3UploadService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/global/util/S3UploadService.java
@@ -192,4 +192,5 @@ public class S3UploadService {
         String str = sdf.format(date);
         return str.replace("-", "/");
     }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,3 +70,4 @@ cloud:
       static: ap-northeast-2
     stack:
       auto: false
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,26 @@
 spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: f97c55d9d92ac41363b532958776d378 # 카카오 restapi key
+            client-secret: 1jJv86Q9mSAko0rnOva7ykjIYfFVY3x8 # 카카오 시크릿 키
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao # 코드를 받는 콜백 주소
+            authorization-grant-type: authorization_code
+            client-authentication-method: POST
+            client-name: Kakao
+            scope:
+              - profile_nickname
+              - account_email
+              - profile_image
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${MYSQL_DATABASE_URL}


### PR DESCRIPTION
변경사항

**AS-IS**

**TO-BE**
- 카카오 소셜로그인 후 강제 회원가입
- 서비스에서 필요한 지역,성향 등 추가 정보 입력 api 추가
- PasswordEncoder 순환 참조 문제
(구조가 SecurityConfig에서 PrincipalOauth2UserService를 참조하고
또 SecurityConfig에서 등록되는 PasswordEncoder를 다시 PrincipalOauth2UserService에서 참조)
로 인해 IAmNotAloneApplication 에서 PasswordEnocder 수동 빈 등록

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 