### PR TITLE
Feat: 좋아요 엔티티 생성 후 기능 변경

### DIFF
--- a/src/main/java/com/hotsix/iAmNotAlone/domain/likes/controller/LikesController.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/likes/controller/LikesController.java
@@ -26,8 +26,7 @@ public class LikesController {
     public ResponseEntity<Boolean> addLikes(@PathVariable Long postId,
         @PathVariable Long memberId) {
         return ResponseEntity.ok(
-            likesRegisterService.addLike(String.valueOf(postId),
-                String.valueOf(memberId)));
+            likesRegisterService.addLike(postId, memberId));
     }
 
     /**
@@ -37,7 +36,6 @@ public class LikesController {
     public ResponseEntity<Boolean> deleteLikes(@PathVariable Long postId,
         @PathVariable Long memberId) {
         return ResponseEntity.ok(
-            likesRemoveService.deleteLike(String.valueOf(postId),
-                String.valueOf(memberId)));
+            likesRemoveService.deleteLike(postId, memberId));
     }
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/likes/entity/Likes.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/likes/entity/Likes.java
@@ -1,0 +1,32 @@
+package com.hotsix.iAmNotAlone.domain.likes.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Likes {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "likes_id")
+    private Long id;
+
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @JoinColumn(name = "post_id")
+    private Long postId;
+
+}

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/likes/repository/LikesRepository.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/likes/repository/LikesRepository.java
@@ -1,0 +1,14 @@
+package com.hotsix.iAmNotAlone.domain.likes.repository;
+
+import com.hotsix.iAmNotAlone.domain.likes.entity.Likes;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LikesRepository extends JpaRepository<Likes, Long> {
+
+    Likes findByMemberIdAndPostId(Long memberId, Long postId);
+
+    List<Likes> findByMemberId(Long memberId);
+}

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/likes/service/LikesGetPostId.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/likes/service/LikesGetPostId.java
@@ -1,0 +1,39 @@
+package com.hotsix.iAmNotAlone.domain.likes.service;
+
+import static com.hotsix.iAmNotAlone.global.exception.business.ErrorCode.NOT_FOUND_USER;
+
+import com.hotsix.iAmNotAlone.domain.likes.entity.Likes;
+import com.hotsix.iAmNotAlone.domain.likes.repository.LikesRepository;
+import com.hotsix.iAmNotAlone.domain.membership.repository.MembershipRepository;
+import com.hotsix.iAmNotAlone.global.exception.business.BusinessException;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LikesGetPostId {
+
+    private final LikesRepository likesRepository;
+    private final MembershipRepository membershipRepository;
+
+
+    /**
+     * 회원이 좋아요 한 게시글 리스트 조회
+     */
+    public List<Long> getLikeList(Long memberId) {
+
+        // membership
+        if(!membershipRepository.existsById(memberId)) {
+            throw new BusinessException(NOT_FOUND_USER);
+        }
+
+        // 회원이 좋아요 한 게시글 리스트
+        return likesRepository.findByMemberId(memberId)
+            .stream()
+            .map(Likes::getPostId)
+            .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/likes/service/LikesRemoveService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/likes/service/LikesRemoveService.java
@@ -3,7 +3,8 @@ package com.hotsix.iAmNotAlone.domain.likes.service;
 import static com.hotsix.iAmNotAlone.global.exception.business.ErrorCode.NOT_FOUND_POST;
 import static com.hotsix.iAmNotAlone.global.exception.business.ErrorCode.NOT_FOUND_USER;
 
-import com.hotsix.iAmNotAlone.domain.membership.entity.Membership;
+import com.hotsix.iAmNotAlone.domain.likes.entity.Likes;
+import com.hotsix.iAmNotAlone.domain.likes.repository.LikesRepository;
 import com.hotsix.iAmNotAlone.domain.membership.repository.MembershipRepository;
 import com.hotsix.iAmNotAlone.domain.post.repository.PostRepository;
 import com.hotsix.iAmNotAlone.global.exception.business.BusinessException;
@@ -21,40 +22,36 @@ public class LikesRemoveService {
     private final RedisUtil redisUtil;
     private final PostRepository postRepository;
     private final MembershipRepository membershipRepository;
+    private final LikesRepository likesRepository;
+
 
 
     /**
      * 좋아요 카운트--
      */
     @Transactional
-    public boolean deleteLike(String postId, String memberId) {
+    public boolean deleteLike(Long postId, Long memberId) {
 
         // id 체크
-        if(!postRepository.existsById(Long.valueOf(postId))) {
+        if(!postRepository.existsById(postId)) {
             throw new BusinessException(NOT_FOUND_POST);
         }
 
-        Membership membership = membershipRepository.findById(Long.valueOf(memberId))
-            .orElseThrow(() -> new BusinessException(NOT_FOUND_USER));
+        if(!membershipRepository.existsById(memberId)) {
+            throw new BusinessException(NOT_FOUND_USER);
+        }
 
-        String key = getLikeKey(postId);
+        // redis 게시글의 좋아요 수 count--
+        String key = redisUtil.getLikeKey(String.valueOf(postId));
         redisUtil.removeLike(key);
 
-        // 회원 좋아요 게시글 list
-        membership.updateLikeList(postId, false);
+        // 회원이 좋아요한 게시글 삭제
+        Likes likes = likesRepository.findByMemberIdAndPostId(memberId, postId);
 
-        // 변경 사항 반영
-        membershipRepository.save(membership);
+        likesRepository.delete(likes);
 
         log.info("likes decrement");
         return false;
     }
 
-
-    /**
-     * redis key 조합
-     */
-    private String getLikeKey(String postId) {
-        return "likes:" + postId;
-    }
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/main/service/MainService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/main/service/MainService.java
@@ -3,6 +3,7 @@ package com.hotsix.iAmNotAlone.domain.main.service;
 import static com.hotsix.iAmNotAlone.global.exception.business.ErrorCode.NOT_FOUND_USER;
 
 import com.hotsix.iAmNotAlone.domain.comments.repository.CommentsRepository;
+import com.hotsix.iAmNotAlone.domain.likes.service.LikesGetPostId;
 import com.hotsix.iAmNotAlone.domain.main.model.dto.MainPostResponse;
 import com.hotsix.iAmNotAlone.domain.main.model.dto.MainResponse;
 import com.hotsix.iAmNotAlone.domain.main.model.dto.PostMainDto;
@@ -29,6 +30,7 @@ import org.springframework.stereotype.Service;
 public class MainService {
 
     private final MembershipGetInfoForMainService forMainService;
+    private final LikesGetPostId likesGetPostId;
 
     private final RegionRepository regionRepository;
     private final MembershipRepository membershipRepository;
@@ -69,7 +71,7 @@ public class MainService {
         log.info("Main enter");
 
         // 로그인한 회원의 게시글
-        List<Long> likesList = forMainService.getLikeList(memberId);
+        List<Long> likesList = likesGetPostId.getLikeList(memberId);
 
         // 로그인한 회원의 성별
         int gender = forMainService.getGender(memberId);

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/membership/entity/Membership.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/membership/entity/Membership.java
@@ -7,17 +7,24 @@ import com.hotsix.iAmNotAlone.domain.membership.model.form.ModifyMembershipForm;
 import com.hotsix.iAmNotAlone.domain.region.entity.Region;
 import com.hotsix.iAmNotAlone.global.auth.common.Role;
 import com.hotsix.iAmNotAlone.global.util.ListToStringConverter;
+import java.time.LocalDate;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.envers.AuditOverride;
-
-import javax.persistence.*;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -45,11 +52,6 @@ public class Membership extends BaseEntity {
 
     @Column(name = "img_path")
     private String imgPath;
-
-    @Convert(converter = ListToStringConverter.class)
-    @Column(name = "likelist")
-    @Default
-    private List<String> likelist = new ArrayList<>();
 
     private String refreshToken;
 
@@ -99,15 +101,15 @@ public class Membership extends BaseEntity {
     /**
      * likelist 수정
      */
-    public void updateLikeList(String postId, boolean isLikeOperation) {
-        this.likelist.remove("");
-
-        if (isLikeOperation) {
-            this.likelist.add(String.valueOf(postId));
-        } else {
-            this.likelist.remove(String.valueOf(postId));
-        }
-    }
+//    public void updateLikeList(Long postId, boolean isLikeOperation) {
+//        this.likes.remove("");
+//
+//        if (isLikeOperation) {
+//            this.likes.add(postId);
+//        } else {
+//            this.likes.remove(String.valueOf(postId));
+//        }
+//    }
 
     public void updateMembership(AddMembershipOAuthForm form, Region region) {
         if (form.getNickname() != null) {

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/membership/service/MembershipGetInfoForMainService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/membership/service/MembershipGetInfoForMainService.java
@@ -5,8 +5,6 @@ import static com.hotsix.iAmNotAlone.global.exception.business.ErrorCode.NOT_FOU
 import com.hotsix.iAmNotAlone.domain.membership.entity.Membership;
 import com.hotsix.iAmNotAlone.domain.membership.repository.MembershipRepository;
 import com.hotsix.iAmNotAlone.global.exception.business.BusinessException;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,22 +14,6 @@ public class MembershipGetInfoForMainService {
 
     private final MembershipRepository membershipRepository;
 
-
-    /**
-     * 회원이 좋아요 한 게시글 리스트 조회
-     */
-    public List<Long> getLikeList(Long memberId) {
-
-        // membership
-        Membership membership = membershipRepository.findById(memberId)
-            .orElseThrow(() -> new BusinessException(NOT_FOUND_USER));
-
-        // 회원이 좋아요 한 게시글 리스트
-        return membership.getLikelist().stream()
-            .filter(s -> !s.isEmpty())   // 빈 문자열 제외
-            .map(Long::parseLong)
-            .collect(Collectors.toList());
-    }
 
     /**
      * 회원의 성별 조회

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/membership/service/MembershipLikesListService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/membership/service/MembershipLikesListService.java
@@ -1,6 +1,7 @@
 package com.hotsix.iAmNotAlone.domain.membership.service;
 
 import com.hotsix.iAmNotAlone.domain.comments.repository.CommentsRepository;
+import com.hotsix.iAmNotAlone.domain.likes.service.LikesGetPostId;
 import com.hotsix.iAmNotAlone.domain.membership.model.dto.LikesListDto;
 import com.hotsix.iAmNotAlone.domain.membership.model.dto.LikesListPostResponse;
 import com.hotsix.iAmNotAlone.domain.post.entity.Post;
@@ -17,7 +18,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class MembershipLikesListService {
 
-    private final MembershipGetInfoForMainService forMainService;
+    private final LikesGetPostId likesGetPostId;
 
     private final PostRepository postRepository;
     private final CommentsRepository commentsRepository;
@@ -30,7 +31,7 @@ public class MembershipLikesListService {
         log.info("member likes List enter");
 
         // 로그인한 회원 좋아요 한 게시글
-        List<Long> likesList = forMainService.getLikeList(memberId);
+        List<Long> likesList = likesGetPostId.getLikeList(memberId);
         
         // 조회해온 좋아요 게시글 리스트
         List<Post> postList =

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/post/controller/PostController.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/post/controller/PostController.java
@@ -4,16 +4,27 @@ import com.hotsix.iAmNotAlone.domain.post.model.dto.PostDetailDto;
 import com.hotsix.iAmNotAlone.domain.post.model.dto.PostResponseDto;
 import com.hotsix.iAmNotAlone.domain.post.model.form.AddPostForm;
 import com.hotsix.iAmNotAlone.domain.post.model.form.ModifyPostForm;
-import com.hotsix.iAmNotAlone.domain.post.service.*;
+import com.hotsix.iAmNotAlone.domain.post.service.PostDetailService;
+import com.hotsix.iAmNotAlone.domain.post.service.PostModifyService;
+import com.hotsix.iAmNotAlone.domain.post.service.PostPageService;
+import com.hotsix.iAmNotAlone.domain.post.service.PostRegisterService;
+import com.hotsix.iAmNotAlone.domain.post.service.PostRemoveService;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,6 +36,7 @@ public class PostController {
     private final PostModifyService postModifyService;
     private final PostPageService postPageService;
     private final PostRemoveService postRemoveService;
+
 
     @PostMapping(value = "/{userId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<Long> postAdd(@PathVariable(name = "userId") Long id,
@@ -62,19 +74,19 @@ public class PostController {
     public ResponseEntity<Result<List<PostResponseDto>>> getPostLowerThanId(@RequestParam Long lastPostId,
                                                                             @RequestParam int size, @PathVariable Long userId) {
         List<PostResponseDto> postResponse = postPageService.postPagesBy(lastPostId, size, userId);
-        return ResponseEntity.ok(new Result(postResponse));
+        return ResponseEntity.ok(new Result<>(postResponse));
     }
 
     // 마이페이지 게시글 세팅 api
     @GetMapping("/basic/{userId}")
     public ResponseEntity<Result<List<PostResponseDto>>> getPostInUserId(@PathVariable Long userId) {
         List<PostResponseDto> postResponse = postPageService.postBasicSetting(userId);
-        return ResponseEntity.ok(new Result(postResponse));
+        return ResponseEntity.ok(new Result<>(postResponse));
     }
 
     @Data
     @AllArgsConstructor
-    public class Result<T> {
+    public static class Result<T> {
         private T data;
     }
 

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/post/service/PostDetailService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/post/service/PostDetailService.java
@@ -1,22 +1,19 @@
 package com.hotsix.iAmNotAlone.domain.post.service;
 
+import static com.hotsix.iAmNotAlone.global.exception.business.ErrorCode.NOT_FOUND_POST;
+
 import com.hotsix.iAmNotAlone.domain.comments.repository.CommentsRepository;
-import com.hotsix.iAmNotAlone.domain.membership.entity.Membership;
-import com.hotsix.iAmNotAlone.domain.membership.repository.MembershipRepository;
+import com.hotsix.iAmNotAlone.domain.likes.service.LikesGetPostId;
 import com.hotsix.iAmNotAlone.domain.post.entity.Post;
 import com.hotsix.iAmNotAlone.domain.post.model.dto.PostDetailDto;
 import com.hotsix.iAmNotAlone.domain.post.repository.PostRepository;
 import com.hotsix.iAmNotAlone.global.exception.business.BusinessException;
 import com.hotsix.iAmNotAlone.global.util.RedisUtil;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.hotsix.iAmNotAlone.global.exception.business.ErrorCode.NOT_FOUND_POST;
-import static com.hotsix.iAmNotAlone.global.exception.business.ErrorCode.NOT_FOUND_USER;
 
 @Slf4j
 @Service
@@ -26,8 +23,10 @@ public class PostDetailService {
 
     private final PostRepository postRepository;
     private final CommentsRepository commentsRepository;
-    private final MembershipRepository membershipRepository;
     private final RedisUtil redisUtil;
+
+    private final LikesGetPostId likesGetPostId;
+
 
     public PostDetailDto findPost(Long postId, Long membershipId) {
         Post post = postRepository.findById(postId).orElseThrow(
@@ -37,13 +36,9 @@ public class PostDetailService {
         PostDetailDto postDetailDto = PostDetailDto.from(post, commentCount);
         log.info("게시글 정보 조회");
 
-        Membership membership = membershipRepository.findById(membershipId).orElseThrow(
-            () -> new BusinessException(NOT_FOUND_USER)
-        );
         // 좋아요 확인
-        List<Long> likeList = membership.getLikelist().stream().filter(s->!s.isEmpty()).map(Long::parseLong).collect(
-            Collectors.toList());
-        postDetailDto.setLike(likeList.isEmpty() ? false : likeList.contains(postId));
+        List<Long> likeList = likesGetPostId.getLikeList(membershipId);
+        postDetailDto.setLike(!likeList.isEmpty() && likeList.contains(postId));
 
         //좋아요 수
         Long likeCount = redisUtil.getLikeCount("likes:" + postId);

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/post/service/PostPageService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/post/service/PostPageService.java
@@ -1,13 +1,12 @@
 package com.hotsix.iAmNotAlone.domain.post.service;
 
 import com.hotsix.iAmNotAlone.domain.comments.repository.CommentsRepository;
+import com.hotsix.iAmNotAlone.domain.likes.service.LikesGetPostId;
 import com.hotsix.iAmNotAlone.domain.membership.entity.Membership;
 import com.hotsix.iAmNotAlone.domain.membership.repository.MembershipRepository;
-import com.hotsix.iAmNotAlone.domain.membership.service.MembershipGetInfoForMainService;
 import com.hotsix.iAmNotAlone.domain.post.entity.Post;
 import com.hotsix.iAmNotAlone.domain.post.model.dto.PostResponseDto;
 import com.hotsix.iAmNotAlone.domain.post.repository.PostRepository;
-import com.hotsix.iAmNotAlone.domain.region.repository.RegionRepository;
 import com.hotsix.iAmNotAlone.global.exception.business.BusinessException;
 import com.hotsix.iAmNotAlone.global.exception.business.ErrorCode;
 import java.util.ArrayList;
@@ -24,15 +23,14 @@ public class PostPageService {
     private final PostRepository postRepository;
     private final MembershipRepository membershipRepository;
     private final CommentsRepository commentsRepository;
-    private final MembershipGetInfoForMainService forMainService;
-    private final RegionRepository regionRepository;
+    private final LikesGetPostId likesGetPostId;
 
     // 페이지
     public List<PostResponseDto> postPagesBy(Long lastPostId, int size, Long userId) {
         Membership membership = membershipRepository.findById(userId).orElseThrow(
                 () -> new BusinessException(ErrorCode.NOT_FOUND_USER)
         );
-        List<Long> likeList = forMainService.getLikeList(membership.getId());
+        List<Long> likeList = likesGetPostId.getLikeList(membership.getId());
         Page<Post> posts = fetchPages(lastPostId, size, userId);
         List<Post> postList = posts.getContent();
 
@@ -60,7 +58,7 @@ public class PostPageService {
                 () -> new BusinessException(ErrorCode.NOT_FOUND_USER)
         );
 
-        List<Long> likeList = forMainService.getLikeList(membership.getId());
+        List<Long> likeList = likesGetPostId.getLikeList(membership.getId());
         List<Post> postList = postRepository.findTop10ByMembershipIdOrderByIdDesc(userId);
 
         List<PostResponseDto> postResponseList = new ArrayList<>();

--- a/src/main/java/com/hotsix/iAmNotAlone/global/util/RedisUtil.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/global/util/RedisUtil.java
@@ -38,6 +38,12 @@ public class RedisUtil {
         redisTemplate.delete(key);
     }
 
+
+    // redis key 조합 (게시글 좋아요 count)
+    public String getLikeKey(String postId) {
+        return "likes:" + postId;
+    }
+
     // count increment
     public void addLike(String key) {
         redisTemplate.opsForValue().increment(key, 1);
@@ -45,7 +51,7 @@ public class RedisUtil {
 
     // count decrement
     public void removeLike(String key) {
-        redisTemplate.opsForValue().decrement(key, 1);
+        redisTemplate.opsForValue().decrement(key);
     }
 
     // findCount

--- a/src/test/java/com/hotsix/iAmNotAlone/domain/likes/service/LikesRegisterRemoveServiceTest.java
+++ b/src/test/java/com/hotsix/iAmNotAlone/domain/likes/service/LikesRegisterRemoveServiceTest.java
@@ -29,19 +29,13 @@
 //    @DisplayName("좋아요 테스트")
 //    void addDeleteLike() throws InterruptedException {
 //
-//        final String postId = "2";  // 게시글 2
+//        final long postId = 2;  // 게시글 2
 //        ExecutorService executorService = Executors.newFixedThreadPool(50);
 //
-//        IntStream.rangeClosed(1, 25).forEach(i -> {
+//        IntStream.rangeClosed(1, 50).forEach(i -> {
 //            executorService.submit(() -> {
-//                String userId = String.valueOf(i + 7); // 로컬 DB의 유저 ID 8부터 시작하므로, i에 7을 더함
-//                likesRegisterService.addLike(postId, userId);
-//            });
-//        });
-//
-//        IntStream.rangeClosed(26, 50).forEach(i -> {
-//            executorService.submit(() -> {
-//                String userId = String.valueOf(i + 7); // 로컬 DB의 유저 ID 8부터 시작하므로, i에 7을 더함
+//                Long userId = Long.valueOf(String.valueOf(i + 7)); // 로컬 DB의 유저 ID 8부터 시작하므로, i에 7을 더함
+////                likesRegisterService.addLike(postId, userId);
 //                likesRemoveService.deleteLike(postId, userId);
 //            });
 //        });
@@ -50,7 +44,9 @@
 //        executorService.awaitTermination(1, TimeUnit.MINUTES);
 //
 //        // 검증 로직. 예를 들면, 게시글의 좋아요 수가 50/0인지, 그리고 각 유저가 해당 게시글을 좋아하는지 확인
-//        assertEquals(0, redisUtil.getLikeCount(postId));
+////        assertEquals(50, redisUtil.getLikeCount("likes:" + postId));
+//        assertEquals(0, redisUtil.getLikeCount("likes:" + postId));
+//
 //
 //    }
 //


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
1. MembershipGetInfoForMainService 클래스에 좋아요한 게시글 조회메서드가 있었음
2. 좋아요 엔티티가 없었음

**TO-BE**
1. 좋아요 entity, repository 생성
2. 연관관계는 membership, post 둘다 안맺고, 인덱스를 걸어줌
3. LikesGetPostId 클래스 생성해 좋아요한 게시글 조회되게 수정
   - 메인 페이지 조회
   - 관심목록 페이지 조회
   - 마이 페이지 게시글 조회
   - 게시글 상세 조회

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트