### PR TITLE
feat: 채팅방에 접속중인 유저가 2명이 아닐때, 알람메세지 전송 기능 추가

### DIFF
--- a/src/main/java/com/hotsix/iAmNotAlone/domain/chat/config/FilterChannelInterceptor.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/chat/config/FilterChannelInterceptor.java
@@ -88,6 +88,7 @@ public class FilterChannelInterceptor implements ChannelInterceptor {
                 log.info("채팅방에 들어와있는 유저수: " + redisUtil.getData("chatRoomId: " + sRoomId));
 
                 String token = accessor.getFirstNativeHeader("Authorization");
+                log.info("token: {}", token);
                 if (token != null && token.startsWith(TOKEN_PREFIX)) {
                     String jwtToken = token.replace(TOKEN_PREFIX, "");
 
@@ -95,12 +96,10 @@ public class FilterChannelInterceptor implements ChannelInterceptor {
                     Long roomId = Long.parseLong(sRoomId);
 
                     Long unReadCount = chatMessageService.unReadCount(roomId, membershipId);
-
                     log.info(unReadCount);
                     if (unReadCount != 0) {
                         chatMessageService.readCheck(roomId, membershipId);
                     }
-
                 }
                 break;
             case UNSUBSCRIBE:
@@ -108,6 +107,7 @@ public class FilterChannelInterceptor implements ChannelInterceptor {
                 log.info("sessionId: {}", sessionId);
                 String dRoomId = redisUtil.getData(sessionId);
                 redisUtil.deleteConnect("chatRoomId: " + dRoomId);
+                redisUtil.deleteData(sessionId);
                 log.info("채팅방에 들어와있는 유저수: " + redisUtil.getData("chatRoomId: " + dRoomId));
 
             case DISCONNECT:

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/chat/config/FilterChannelInterceptor.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/chat/config/FilterChannelInterceptor.java
@@ -109,12 +109,11 @@ public class FilterChannelInterceptor implements ChannelInterceptor {
                 redisUtil.deleteConnect("chatRoomId: " + dRoomId);
                 redisUtil.deleteData(sessionId);
                 log.info("채팅방에 들어와있는 유저수: " + redisUtil.getData("chatRoomId: " + dRoomId));
-
+                break;
             case DISCONNECT:
                 // 웹소켓 클라이언트가 disconnect()를 호출하여 연결을 종료한 경우 또는 세션이 끊어진 경우
                 log.info("DISCONNECT");
                 log.info("sessionId: {}", sessionId);
-
                 break;
             case SEND:
                 log.info("SEND");

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/chat/controller/ChatMessageController.java
@@ -1,11 +1,16 @@
 package com.hotsix.iAmNotAlone.domain.chat.controller;
 
 import static com.hotsix.iAmNotAlone.global.exception.business.ErrorCode.NOT_FOUND_CHATROOM;
+import static com.hotsix.iAmNotAlone.global.exception.business.ErrorCode.NOT_FOUND_USER;
 
 import com.hotsix.iAmNotAlone.domain.chat.domain.ChatRoom;
 import com.hotsix.iAmNotAlone.domain.chat.dto.AddChatMessageFrom;
+import com.hotsix.iAmNotAlone.domain.chat.dto.ChatMessage2Dto;
 import com.hotsix.iAmNotAlone.domain.chat.repository.ChatRoomRepository;
 import com.hotsix.iAmNotAlone.domain.chat.service.ChatMessageService;
+import com.hotsix.iAmNotAlone.domain.membership.entity.Membership;
+import com.hotsix.iAmNotAlone.domain.membership.model.dto.MembershipSummaryDto;
+import com.hotsix.iAmNotAlone.domain.membership.repository.MembershipRepository;
 import com.hotsix.iAmNotAlone.global.exception.business.BusinessException;
 import com.hotsix.iAmNotAlone.global.util.RedisUtil;
 import java.util.Objects;
@@ -26,29 +31,40 @@ public class ChatMessageController {
     private final ChatMessageService chatMessageService;
     private final RedisUtil redisUtil;
     private final ChatRoomRepository chatRoomRepository;
+    private final MembershipRepository membershipRepository;
 
     @MessageMapping("/chat/send")
     public void sendToMessage(AddChatMessageFrom form) {
         // 여기서 상대방이 구독중인지 확인을 하고 구독중이면 unRead를 0으로 저장
 
+        // 상대방이 구독중하고 있지 않다면 unRead를 1로 저장, 상대방에게 알람메세지 전송
+        log.info("connect: " + redisUtil.getData("chatRoomId: " + form.getChatRoomId()));
+        if (!redisUtil.getData("chatRoomId: " + form.getChatRoomId()).equals("2")) {
+            form.setUnRead(1);
 
-        // 상대방이 구독중하고 있지 않다면 unRead를 1로 저장
-        log.info("connect: " + redisUtil.getData(String.valueOf(form.getChatRoomId())));
+            ChatRoom chatRoom = chatRoomRepository.findById(form.getChatRoomId()).orElseThrow(
+                () -> new BusinessException(NOT_FOUND_CHATROOM)
+            );
 
-        simpMessagingTemplate.convertAndSend("/sub/room/" + form.getChatRoomId(), form);
+            Long receiverId;
+            Membership sender;
+            if (Objects.equals(chatRoom.getSender().getId(), form.getSenderId())) {
+                receiverId = chatRoom.getReceiver().getId();
+                sender = chatRoom.getSender();
+            } else {
+                receiverId = chatRoom.getSender().getId();
+                sender = chatRoom.getReceiver();
+            }
 
-        ChatRoom chatRoom = chatRoomRepository.findById(form.getChatRoomId()).orElseThrow(
-            () -> new BusinessException(NOT_FOUND_CHATROOM)
-        );
-
-        Long receiverId;
-        if (Objects.equals(chatRoom.getSender().getId(), form.getSenderId())) {
-            receiverId = chatRoom.getReceiver().getId();
-        } else {
-            receiverId = chatRoom.getSender().getId();
+            ChatMessage2Dto alarmMessage = ChatMessage2Dto.from(form, MembershipSummaryDto.from(sender));
+            simpMessagingTemplate.convertAndSend("/sub/membership/" + receiverId, alarmMessage);
         }
 
-        simpMessagingTemplate.convertAndSend("/sub/membership/" + receiverId, form);
+        // 채팅방으로 메세지 브로드캐스팅
+        simpMessagingTemplate.convertAndSend("/sub/room/" + form.getChatRoomId(), form);
+
+
+        // 채팅 메세지 DB에 저장
         chatMessageService.addMessage(form);
 
     }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/chat/controller/ChatRoomController.java
@@ -44,4 +44,5 @@ public class ChatRoomController {
 //        chatMessageService.readCheck(roomId, membershipId);
 //        return ResponseEntity.ok().build();
 //    }
+
 }

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/chat/dto/AddChatMessageFrom.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/chat/dto/AddChatMessageFrom.java
@@ -2,8 +2,10 @@ package com.hotsix.iAmNotAlone.domain.chat.dto;
 
 import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class AddChatMessageFrom {
 
     private Long chatRoomId;

--- a/src/main/java/com/hotsix/iAmNotAlone/domain/chat/dto/ChatMessage2Dto.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/chat/dto/ChatMessage2Dto.java
@@ -1,0 +1,31 @@
+package com.hotsix.iAmNotAlone.domain.chat.dto;
+
+import com.hotsix.iAmNotAlone.domain.chat.domain.ChatMessage;
+import com.hotsix.iAmNotAlone.domain.membership.model.dto.MembershipSummaryDto;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Builder
+@Setter
+public class ChatMessage2Dto {
+
+    private Long chatRoomId;
+    private MembershipSummaryDto membership;
+    private String message;
+    private LocalDateTime createdAt;
+    private int unRead;
+
+    public static ChatMessage2Dto from(AddChatMessageFrom chatMessage, MembershipSummaryDto membership) {
+        return ChatMessage2Dto.builder()
+            .chatRoomId(chatMessage.getChatRoomId())
+            .membership(membership)
+            .message(chatMessage.getMessage())
+            .createdAt(chatMessage.getCreatedAt())
+            .unRead(chatMessage.getUnRead())
+            .build();
+    }
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 프론트에서 polling 방식으로 5초마다 채팅 리스트 정보를 요청함

**TO-BE**
- 웹소켓을 로그인시 연결하고 로그인한 유저의 아이디로 구독을 함
- 채팅방에 접속중인 유저가 2명이 아닐때, receiver에게 알람메세지 전송 기능 추가

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 