### PR TITLE
refactor: 소셜로그인한 유저 이미지 수정시 s3에서 delete하는 로직 제외

### DIFF
--- a/src/main/java/com/hotsix/iAmNotAlone/domain/membership/service/MembershipModifyService.java
+++ b/src/main/java/com/hotsix/iAmNotAlone/domain/membership/service/MembershipModifyService.java
@@ -56,9 +56,15 @@ public class MembershipModifyService {
         // 1. 새로 업로드 하는 파일이 있다
         if (multipartFiles.get(0).getSize() != 0) {
             // 1-2. 기존에 파일이 있다. -> 기존 파일 s3 버킷에서 삭제
+
             if (member.getImgPath().length() != 0) {
-                String[] split = member.getImgPath().split("com/");
-                s3UploadService.deleteFile(split[1]);
+                String[] sp = member.getImgPath().split("\\.");
+
+                // 카카오에서 가져온 이미지가 아니면 s3
+                if (!sp[1].equals("kakaocdn")) {
+                    String[] split = member.getImgPath().split("com/");
+                    s3UploadService.deleteFile(split[1]);
+                }
             }
             // 1-1. 기존에 파일이 없다. -> 삭제 없이 s3 버킷에 업로드
             List<S3FileDto> s3FileDtos = s3UploadService.uploadFiles(multipartFiles);


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 소셜 로그인한 유저가 회원수정에서 이미지 수정시 에러발생

**TO-BE**
- 소셜로그인한 유저 이미지 수정시 s3에서 delete하는 로직 제외

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] API 테스트 